### PR TITLE
Upgrade @glimmer/blueprint and bring back ember-web-app.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
+    "build": "ember build -e production",
     "start": "ember server",
     "test": "ember test"
   },
   "devDependencies": {
     "@glimmer/application": "^0.7.2",
-    "@glimmer/application-pipeline": "^0.8.0",
-    "@glimmer/blueprint": "^0.5.0",
+    "@glimmer/application-pipeline": "^0.8.3",
+    "@glimmer/blueprint": "^0.5.3",
     "@glimmer/inline-precompile": "^1.0.0",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/test-helpers": "^0.30.0",
@@ -27,12 +27,12 @@
     "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-sass": "^6.2.0",
-    "ember-cli-uglify": "^1.2.0",
+    "ember-cli-uglify": "^2.0.0-beta.1",
     "ember-service-worker": "^0.6.7",
     "ember-service-worker-asset-cache": "^0.6.1",
     "ember-service-worker-cache-fallback": "^0.6.1",
     "flickity": "2.0.8",
-    "qunitjs": "^2.3.3",
+    "qunitjs": "^2.4.0",
     "typescript": "^2.2.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-service-worker": "^0.6.7",
     "ember-service-worker-asset-cache": "^0.6.1",
     "ember-service-worker-cache-fallback": "^0.6.1",
+    "ember-web-app": "^2.0.0",
     "flickity": "2.0.8",
     "qunitjs": "^2.4.0",
     "typescript": "^2.2.2"

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -12,27 +12,6 @@
 
     {{content-for "head"}}
 
-<!--
-  ember-web-app will generate these tags from config/manifest.json, however
-  it doesn't yet generate the manifest.json dist file yet. So, inline for
-  now.
--->
-<link rel="manifest" href="/manifest.json">
-<link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon-60x60.png" sizes="60x60">
-<link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon-76x76.png" sizes="76x76">
-<link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon-120x120.png" sizes="120x120">
-<link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon-152x152.png" sizes="152x152">
-<link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon-180x180.png" sizes="180x180">
-<link rel="apple-touch-icon" href="/assets/images/icons/android-chrome-192x192.jpg" sizes="192x192">
-<link rel="apple-touch-icon" href="/assets/images/icons/android-chrome-512x512.jpg" sizes="512x512">
-<meta name="theme-color" content="#fff">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-title" content="Shop 201">
-<meta name="apple-mobile-web-app-status-bar-style" content="default">
-<!--
-  end ember-web-app content
--->
-
     <link rel="icon" type="image/png" href="{{rootURL}}assets/images/icons/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="{{rootURL}}assets/images/icons/android-chrome-192x192.jpg" sizes="192x192">
     <link rel="icon" type="image/png" href="{{rootURL}}assets/images/icons/favicon-16x16.png" sizes="16x16">

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,11 +631,17 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
-babel-plugin-debug-macros@^0.1.7:
+babel-plugin-debug-macros@^0.1.11, babel-plugin-debug-macros@^0.1.7:
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   dependencies:
     semver "^5.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.4.2.tgz#e254f8ed0ba7cf32ea6a71c4770b3568a8577402"
+  dependencies:
+    ember-rfc176-data "^0.2.0"
 
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
@@ -911,6 +917,14 @@ babel-plugin-undeclared-variables-check@^1.0.2:
 babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
+
+babel-polyfill@^6.16.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
 
 babel-preset-env@^1.5.1:
   version "1.6.0"
@@ -2197,6 +2211,23 @@ ember-cli-babel@^5.1.6:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
+ember-cli-babel@^6.0.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.6.0.tgz#a8362bc44841bfdf89b389f3197f104d7ba526da"
+  dependencies:
+    amd-name-resolver "0.0.6"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^1.4.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.0.0"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
+
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.0.4.tgz#f43f42f75b7509c212fb926cd9aea86ae19264c6"
@@ -2319,6 +2350,13 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.6, ember-cli-ve
   dependencies:
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz#e1f7d8e4cdcd752ac35f1611e4daa8836db4c4c7"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.0.tgz#9aff1414168883183e8677fa32626d1e3228ccbc"
@@ -2409,6 +2447,10 @@ ember-cli@^2.14.0:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
+ember-rfc176-data@^0.2.0:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.4.tgz#f6c5e52ffb14cf66c9fed5bd70fbe68fc91982e9"
+
 ember-router-generator@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
@@ -2476,6 +2518,16 @@ ember-try@^0.2.15:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
+
+ember-web-app@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-web-app/-/ember-web-app-2.0.0.tgz#56c825d835fa9c3f6cb7901a5687c50c91341edf"
+  dependencies:
+    broccoli-asset-rev "^2.5.0"
+    broccoli-plugin "^1.3.0"
+    ember-cli-babel "^6.0.0"
+    object-assign "^4.1.1"
+    web-app-manifest-validator "^1.0.0"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -3091,7 +3143,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1, glob@^7.1.1:
+glob@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3112,7 +3164,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -3407,6 +3459,10 @@ invert-kv@^1.0.0:
 ipaddr.js@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
+
+is-array@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -4802,6 +4858,12 @@ resolve@1.3.2, resolve@^1.1.2, resolve@^1.1.6, resolve@^1.3.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -5587,6 +5649,12 @@ walker@~1.0.5:
 watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+
+web-app-manifest-validator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/web-app-manifest-validator/-/web-app-manifest-validator-1.0.0.tgz#b4265b83d527bbd2f89a217c2d49ce26b24ac204"
+  dependencies:
+    is-array "^1.0.1"
 
 websocket-driver@>=0.5.1:
   version "0.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@glimmer/application-pipeline@^0.8.0":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/application-pipeline/-/application-pipeline-0.8.1.tgz#1747d497002c901bdffdace448cd4da65a340372"
+"@glimmer/application-pipeline@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/application-pipeline/-/application-pipeline-0.8.3.tgz#7348490ab14ff49692588e854e4ddf5fd8b50440"
   dependencies:
     "@glimmer/resolution-map-builder" "^0.5.1"
     "@glimmer/resolver-configuration-builder" "^0.1.2"
@@ -18,6 +18,7 @@
     broccoli-config-loader "^1.0.0"
     broccoli-config-replace "^1.1.2"
     broccoli-debug "^0.6.2"
+    broccoli-file-creator "^1.1.1"
     broccoli-merge-trees "^2.0.0"
     broccoli-persistent-filter "^1.3.1"
     broccoli-rollup "^1.3.0"
@@ -57,9 +58,9 @@
     "@glimmer/runtime" "^0.26.2"
     "@glimmer/util" "^0.26.2"
 
-"@glimmer/blueprint@^0.5.0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-0.5.1.tgz#55fb3fa89f47c76bc03bab571a7b8b6693d56155"
+"@glimmer/blueprint@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-0.5.3.tgz#9aed2f9260ee5503436178b4dd3e2cc7d83b2cec"
   dependencies:
     ember-cli-string-utils "^1.1.0"
 
@@ -1519,7 +1520,7 @@ broccoli-typescript-compiler@^1.0.1:
     md5-hex "^1.3.0"
     walk-sync "^0.3.1"
 
-broccoli-uglify-sourcemap@^1.0.0, broccoli-uglify-sourcemap@^1.4.0, broccoli-uglify-sourcemap@^1.5.1:
+broccoli-uglify-sourcemap@^1.4.0, broccoli-uglify-sourcemap@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.2.tgz#04f84ab0db539031fa868ccfa563c9932d50cedb"
   dependencies:
@@ -1531,6 +1532,20 @@ broccoli-uglify-sourcemap@^1.0.0, broccoli-uglify-sourcemap@^1.4.0, broccoli-ugl
     source-map-url "^0.3.0"
     symlink-or-copy "^1.0.1"
     uglify-js "^2.7.0"
+    walk-sync "^0.1.3"
+
+broccoli-uglify-sourcemap@^2.0.0-beta.1:
+  version "2.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.0-beta.2.tgz#0b99e3364f41ee4680471ff9979150ca764ab282"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    debug "^2.2.0"
+    lodash.defaultsdeep "^4.6.0"
+    matcher-collection "^1.0.0"
+    mkdirp "^0.5.0"
+    source-map-url "^0.3.0"
+    symlink-or-copy "^1.0.1"
+    uglify-es "^3.0.24"
     walk-sync "^0.1.3"
 
 broccoli-writer@~0.1.1:
@@ -1817,7 +1832,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.0, commander@^2.5.0, commander@^2.6.0:
+commander@2.9.0, commander@^2.5.0, commander@^2.6.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2285,11 +2300,12 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-uglify@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-1.2.0.tgz#3208c32b54bc2783056e8bb0d5cfe9bbaf17ffb2"
+ember-cli-uglify@^2.0.0-beta.1:
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-2.0.0-beta.1.tgz#9cb509f7f3f3342271df4a59b41176f0ffbda48a"
   dependencies:
-    broccoli-uglify-sourcemap "^1.0.0"
+    broccoli-uglify-sourcemap "^2.0.0-beta.1"
+    lodash.defaultsdeep "^4.6.0"
 
 ember-cli-valid-component-name@^1.0.0:
   version "1.0.0"
@@ -3075,7 +3091,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1:
+glob@7.1.1, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3096,7 +3112,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4529,9 +4545,9 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunitjs@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.3.3.tgz#456696bdd61a2c8b5bc8f053f00e20d75a73d539"
+qunitjs@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.0.tgz#58f3a81e846687f2e7f637c5bedc9c267f887261"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"
@@ -5418,6 +5434,13 @@ typescript@^2.2.2:
 uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
+
+uglify-es@^3.0.24:
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.24.tgz#fab5dccff6108df71d9573012ef65c740cb97cdc"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
 
 uglify-js@^2.6, uglify-js@^2.7.0:
   version "2.8.29"


### PR DESCRIPTION
To ensure the correct meta tags are present, I created this before/after gist that you can review:

https://gist.github.com/rwjblue/0a3e7f598f3dceea08a61a5cbb9440b5/revisions